### PR TITLE
make pages use static props

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import RecentCommits from "../components/RecentCommits";
 import Description from "../components/about/Description";
 import Head from "next/head";
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   // Call an external API endpoint to get posts.
   // You can use any data fetching library
 
@@ -16,6 +16,7 @@ export async function getServerSideProps() {
     props: {
       commits,
     },
+    revalidate: 30,
   };
 }
 

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -1,7 +1,7 @@
 import ProjectCard from "../components/ProjectCard";
 import NavBar from "../components/NavBar";
 import Head from "next/head";
-export async function getServerSideProps() {
+export async function getStaticProps() {
   // Call an external API endpoint to get posts.
   // You can use any data fetching library
 
@@ -11,6 +11,7 @@ export async function getServerSideProps() {
     props: {
       projects: prjs,
     },
+    revalidate: 100,
   };
 }
 

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -17,7 +17,7 @@ function getCommit(commits) {
   };
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   // Call an external API endpoint to get posts.
   // You can use any data fetching library
 
@@ -58,6 +58,7 @@ export async function getServerSideProps() {
     props: {
       timeline,
     },
+    revalidate: 30,
   };
 }
 


### PR DESCRIPTION
Instead of getServerSideProps().

Hopefully, this will reduce page load times.